### PR TITLE
Refactor and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,24 @@ Write tests using the following convention:
 
 Example:
 
-    describe 'Arenas Requests' do
-      describe 'arenas [/v1/arenas]' do
-          describe 'create an arena [POST]' do
-            it 'responds with the created arena' do
-              arena = build :arena, foursquare_id: '5104'
-              post v1_arena_path(arena)
-    
-              response.status.should eq(201)
-            end
-          end
+```ruby
+describe 'Arenas Requests' do
+  describe 'arenas [/v1/arenas]' do
+      describe 'create an arena [POST]' do
+        it 'responds with the created arena' do
+          arena = build :arena, foursquare_id: '5104'
+          post v1_arena_path(arena)
+
+          response.status.should eq(201)
         end
+      end
     end
+end
+```
 
 The output:
 
-    # Arenas
+    # Group Arenas
     
     ## arenas [/v1/arenas]
     
@@ -76,11 +78,6 @@ The output:
           }
         }
 
-## Caveats
-
-401, 403 and 301 statuses are ignored since rspec produces a undesired output.
-
-TODO: Add option to choose ignored statuses.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,78 @@ The output:
           }
         }
 
+### Multiple transaction examples
+
+```ruby
+describe 'Arenas Requests' do
+  describe 'arenas [/v1/arenas]' do
+      describe 'create an arena [POST]' do
+        it 'responds with the created arena', as: 'succeed' do
+          arena = build :arena, foursquare_id: '5104'
+          post v1_arena_path(arena)
+
+          response.status.should eq(201)
+        end
+
+        it 'responds with the created arena', as: 'with errors' do
+          arena = build :arena, foursquare_id: '5104'
+          post v1_arena_path({with: :wrongd_data})
+
+          response.status.should eq(400)
+        end
+      end
+    end
+end
+```
+
+The output:
+
+    # Group Arenas
+    
+    ## arenas [/v1/arenas]
+    
+    ### create an arena [POST]
+    + Request succeed
+        + Headers
+            
+        + Body
+            {
+                "id": "4e9dbbc2-830b-41a9-b7db-9987735a0b2a",
+                "name": "Clinton St. Baking Co. & Restaurant",
+                "latitude": 40.721294,
+                "longitude": -73.983994,
+                "foursquare_id": "5104"
+            }
+
+    + Response 200 (application/json)
+
+        {
+          "arena": {
+            "id": "4e9dbbc2-830b-41a9-b7db-9987735a0b2a",
+            "name": "Clinton St. Baking Co. & Restaurant",
+            "latitude": 40.721294,
+            "longitude": -73.983994,
+            "foursquare_id": "5104"
+          }
+        }
+
+    + Request with errors
+        + Headers
+            
+        + Body
+            {
+                "id": "4e9dbbc2-830b-41a9-b7db-9987735a0b2a",
+                "name": "Clinton St. Baking Co. & Restaurant",
+                "latitude": 40.721294,
+                "longitude": -73.983994,
+                "foursquare_id": "5104"
+            }
+
+    + Response 400 (application/json)
+
+        {
+          "error": "invalid data provided"
+        }
 
 ## Contributing
 

--- a/lib/rspec_api_blueprint.rb
+++ b/lib/rspec_api_blueprint.rb
@@ -9,9 +9,16 @@ RSpec.configure do |config|
     Dir.glob(File.join(api_docs_folder_path, '*_blueprint.md')).each do |f|
       File.delete(f)
     end
+    SpecBlueprintTranslator.begin
+  end
+
+  config.after(:each, type: :request) do |example|
+    SpecBlueprintTranslator.record_example(example, request, response)
   end
 
   config.after(:suite) do
+    SpecBlueprintTranslator.end
+
     append = -> (handle, file) { handle.puts File.read(File.join(api_docs_folder_path, file)) }
 
     File.open(File.join(api_docs_folder_path, 'apiary.apib'), 'wb') do |apiary|
@@ -28,17 +35,6 @@ RSpec.configure do |config|
 
         append.call(apiary, File.basename(file))
       end
-    end
-  end
-
-  config.after(:each, type: :request) do |example|
-    translator = SpecBlueprintTranslator.new(example, request, response)
-
-    if translator.can_make_blueprint?
-      translator.open_file_from_grouping
-      translator.write_resource_to_file
-      translator.write_action_to_file
-      translator.close_file
     end
   end
 end

--- a/lib/rspec_api_blueprint/spec_blueprint_action.rb
+++ b/lib/rspec_api_blueprint/spec_blueprint_action.rb
@@ -10,12 +10,13 @@ class SpecBlueprintAction
     @requests = []
   end
 
-  def add_request_with_response(request, response)
-    @requests << [
-      render_request(request),
-      render_response(response),
-      request_content_type(request)
-    ]
+  def add_transaction_example(request, response, title)
+    @requests << {
+      request: render_request(request),
+      response: render_response(response),
+      mime_type: request_content_type(request),
+      title: title
+    }
   end
 
   def render_requests
@@ -86,8 +87,8 @@ class SpecBlueprintAction
     include_suffix = @requests.count > 1
     @requests.each_with_index.map do |rr, index|
       title_suffix = include_suffix ? title_suffix(index + 1) : ''
-      title = "Request #{title_suffix} (#{rr[2]})"
-      yield rr[0], rr[1], title
+      title = "Request #{rr[:title] || title_suffix} (#{rr[2]})"
+      yield rr[:request], rr[:response], title
     end
   end
 

--- a/lib/rspec_api_blueprint/spec_blueprint_action.rb
+++ b/lib/rspec_api_blueprint/spec_blueprint_action.rb
@@ -35,7 +35,7 @@ class SpecBlueprintAction
   def render_response(response)
     buffer = "+ Response #{response.status} (#{response.content_type}; charset=#{response.charset})\n\n"
 
-    return buffer unless response.body.present? && response.content_type.to_s =~ %r{application/json}
+    return buffer unless response.body.present? && json_mime_type == response.content_type.to_s
     buffer << "#{JSON.pretty_generate(JSON.parse(response.body))}\n\n".indent(8)
   end
 
@@ -65,7 +65,7 @@ class SpecBlueprintAction
   def request_body(request)
     request_body = request.body.read
     # Request Body
-    return '' unless request_body.present? && request.content_type.to_s == 'application/json'
+    return '' unless request_body.present? && json_mime_type == request.content_type.to_s
     "+ Body\n\n".indent(4) +
       JSON.pretty_generate(JSON.parse(request.body.read)).indent(12)
   end
@@ -104,5 +104,9 @@ class SpecBlueprintAction
       s.prepend(ALPHABET[r])
     end
     s
+  end
+
+  def json_mime_type
+    @json_mime_type ||= Mime::Type.lookup('application/json')
   end
 end

--- a/lib/rspec_api_blueprint/spec_blueprint_action.rb
+++ b/lib/rspec_api_blueprint/spec_blueprint_action.rb
@@ -1,0 +1,108 @@
+class SpecBlueprintAction
+  ALLOWED_HEADERS = %w(HTTP_AUTHORIZATION AUTHORIZATION)
+  ALPHABET = ('A'..'Z').to_a
+
+  attr_accessor :request_method, :identifier
+
+  def initialize(request_method, identifier)
+    @request_method = request_method
+    @identifier = identifier
+    @requests = []
+  end
+
+  def add_request_with_response(request, response)
+    @requests << [
+      render_request(request),
+      render_response(response),
+      request_content_type(request)
+    ]
+  end
+
+  def render_requests
+    each_request_with_reponse do |request, response, title|
+      "+ #{title}\n\n#{request}\n\n#{response}"
+    end.join("\n\n")
+  end
+
+  def render_request(request)
+    [
+      request_parameters(request),
+      request_headers(request),
+      request_body(request)
+    ].compact.join("\n\n")
+  end
+
+  def render_response(response)
+    buffer = "+ Response #{response.status} (#{response.content_type}; charset=#{response.charset})\n\n"
+
+    return buffer unless response.body.present? && response.content_type.to_s =~ %r{application/json}
+    buffer << "#{JSON.pretty_generate(JSON.parse(response.body))}\n\n".indent(8)
+  end
+
+  def to_s
+    "### #{identifier} [#{request_method}]\n\n" +
+      render_requests
+  end
+
+  private
+
+  def request_content_type(request)
+    request.env['CONTENT_TYPE'] || request.content_type
+  end
+
+  def request_headers(request)
+    env = request.env ? request.env : request.headers
+    headers = env.map do |header, value|
+      next unless ALLOWED_HEADERS.include?(header)
+      header = header.gsub(/HTTP_/, '')
+      header = header.gsub(/\ACONTENT_TYPE\z/, 'CONTENT-TYPE')
+      "#{header}: #{value}".indent(12)
+    end.compact
+    return unless headers.any?
+    "+ Headers\n\n".indent(4) + headers.join("\n")
+  end
+
+  def request_body(request)
+    request_body = request.body.read
+    # Request Body
+    return '' unless request_body.present? && request.content_type.to_s == 'application/json'
+    "+ Body\n\n".indent(4) +
+      JSON.pretty_generate(JSON.parse(request.body.read)).indent(12)
+  end
+
+  def request_parameters(request)
+    return unless request.env['QUERY_STRING'].present?
+    params = "+ Parameters\n\n".indent(4)
+    query_strings = URI.decode(request.env['QUERY_STRING']).split('&')
+
+    query_strings.each do |value|
+      key, example = value.split('=')
+      params << "+ #{key} = '#{example}'\n".indent(12)
+    end
+    params
+  end
+
+  def each_request_with_reponse
+    include_suffix = @requests.count > 1
+    @requests.each_with_index.map do |rr, index|
+      title_suffix = include_suffix ? title_suffix(index + 1) : ''
+      title = "Request #{title_suffix} (#{rr[2]})"
+      yield rr[0], rr[1], title
+    end
+  end
+
+  # Returns a sequence of letters for a given number, eg:
+  # 1 => "A"
+  # 2 => "B"
+  # 26 => "Z"
+  # 27 => "AA"
+  # 28 => "AB"
+  def title_suffix(i)
+    s = ''
+    until i.zero?
+      i, r = (i - 1).divmod(26)
+      s.prepend(ALPHABET[r])
+    end
+    s
+  end
+end

--- a/lib/rspec_api_blueprint/spec_blueprint_action.rb
+++ b/lib/rspec_api_blueprint/spec_blueprint_action.rb
@@ -7,11 +7,11 @@ class SpecBlueprintAction
   def initialize(request_method, identifier)
     @request_method = request_method
     @identifier = identifier
-    @requests = []
+    @examples = []
   end
 
   def add_transaction_example(request, response, title)
-    @requests << {
+    @examples << {
       request: render_request(request),
       response: render_response(response),
       mime_type: request_content_type(request),
@@ -19,7 +19,7 @@ class SpecBlueprintAction
     }
   end
 
-  def render_requests
+  def render_examples
     each_request_with_reponse do |request, response, title|
       "+ #{title}\n\n#{request}\n\n#{response}"
     end.join("\n\n")
@@ -42,7 +42,7 @@ class SpecBlueprintAction
 
   def to_s
     "### #{identifier} [#{request_method}]\n\n" +
-      render_requests
+      render_examples
   end
 
   private
@@ -52,7 +52,7 @@ class SpecBlueprintAction
   end
 
   def request_headers(request)
-    env = request.env ? request.env : request.headers
+    env = request.env || request.headers
     headers = env.map do |header, value|
       next unless ALLOWED_HEADERS.include?(header)
       header = header.gsub(/HTTP_/, '')
@@ -84,11 +84,11 @@ class SpecBlueprintAction
   end
 
   def each_request_with_reponse
-    include_suffix = @requests.count > 1
-    @requests.each_with_index.map do |rr, index|
+    include_suffix = @examples.count > 1
+    @examples.each_with_index.map do |example, index|
       title_suffix = include_suffix ? title_suffix(index + 1) : ''
-      title = "Request #{rr[:title] || title_suffix} (#{rr[:mime_type]})"
-      yield rr[:request], rr[:response], title
+      title = "Request #{example[:title] || title_suffix} (#{example[:mime_type]})"
+      yield example[:request], example[:response], title
     end
   end
 

--- a/lib/rspec_api_blueprint/spec_blueprint_action.rb
+++ b/lib/rspec_api_blueprint/spec_blueprint_action.rb
@@ -87,7 +87,7 @@ class SpecBlueprintAction
     include_suffix = @requests.count > 1
     @requests.each_with_index.map do |rr, index|
       title_suffix = include_suffix ? title_suffix(index + 1) : ''
-      title = "Request #{rr[:title] || title_suffix} (#{rr[2]})"
+      title = "Request #{rr[:title] || title_suffix} (#{rr[:mime_type]})"
       yield rr[:request], rr[:response], title
     end
   end

--- a/lib/rspec_api_blueprint/spec_blueprint_group.rb
+++ b/lib/rspec_api_blueprint/spec_blueprint_group.rb
@@ -1,0 +1,20 @@
+require 'rspec_api_blueprint/spec_blueprint_resource'
+
+class SpecBlueprintGroup
+  attr_accessor :name, :resources
+
+  def initialize(name)
+    @name = name
+    @resources = {}
+  end
+
+  def to_s
+    return unless @resources.any?
+    @resources.values.map(&:to_s).join
+  end
+
+  def file_path
+    file_name = @name.tr(' ', '').underscore
+    "#{api_docs_folder_path}#{file_name}_blueprint.md"
+  end
+end

--- a/lib/rspec_api_blueprint/spec_blueprint_resource.rb
+++ b/lib/rspec_api_blueprint/spec_blueprint_resource.rb
@@ -1,0 +1,21 @@
+require 'rspec_api_blueprint/spec_blueprint_action'
+
+class SpecBlueprintResource
+  attr_accessor :name, :actions, :description
+
+  def initialize(name, description)
+    @name = name
+    @description = description
+    @actions = {}
+  end
+
+  def to_s
+    "## #{description} [#{name}]\n#{render_actions}"
+  end
+
+  private
+
+  def render_actions
+    actions.values.join("\n")
+  end
+end

--- a/lib/rspec_api_blueprint/spec_blueprint_translator.rb
+++ b/lib/rspec_api_blueprint/spec_blueprint_translator.rb
@@ -1,141 +1,76 @@
+require 'rspec_api_blueprint/spec_blueprint_group'
+
 class SpecBlueprintTranslator
-  @@actions_covered = {}
-
-  def initialize(example, request, response)
-    group_metas = []
-    group_meta = example.example_group.metadata
-
-    while group_meta.present?
-      group_metas << group_meta
-      group_meta = group_meta[:parent_example_group]
+  class << self
+    def begin
+      @groups = {}
     end
 
-    @example = example
-    @action_group = group_metas[-3]
-    @resource_group = group_metas[-2]
-    @grouping_group = group_metas[-1]
+    def record_example(example, request, response)
+      group_metas = example_group_metas(example)
 
-    @request = request
-    @response = response
-  end
+      return unless group_metas.count >= 3 &&
+                    example.metadata[:document] == true
 
-  def can_make_blueprint?
-    @action_group.present? && @resource_group.present? && @grouping_group.present? && @example.metadata[:document] === true && basic_status?
-  end
+      name = group_name(group_metas[-1])
+      group = (@groups[name] ||= SpecBlueprintGroup.new(name))
 
-  def basic_status?
-    response.status == 200 || response.status == 201 || response.status == 202
-  end
+      name = resource_name(group_metas[-2])
+      resource = (group.resources[name] ||= SpecBlueprintResource.new(name, resource_description(group_metas[-2])))
 
-  attr_reader :request
+      request_method = request_method(group_metas)
+      action = (resource.actions[request_method] ||= SpecBlueprintAction.new(request_method, action_indetifier(group_metas)))
+      action.add_request_with_response request, response
+    end
 
-  attr_reader :response
+    def end
+      write_resources
+    end
 
-  def resource
-    @resource_group[:description_args].first.match(/(.+)\[(.+)\]/)
-    Regexp.last_match(2)
-  end
+    private
 
-  def resource_description
-    @resource_group[:description_args].first.match(/(.+)\[(.+)\]/)
-    Regexp.last_match(1)
-  end
+    def example_group_metas(example)
+      group_metas = []
+      group_meta = example.example_group.metadata
 
-  def action
-    @action_group[:description_args].first.match(/(.+)\[(.+)\]/)
-    Regexp.last_match(2).upcase
-  end
+      while group_meta.present?
+        group_metas << group_meta
+        group_meta = group_meta[:parent_example_group]
+      end
+      group_metas
+    end
 
-  def action_description
-    @action_group[:description_args].first.match(/(.+)\[(.+)\]/)
-    Regexp.last_match(1)
-  end
-
-  def open_file_from_grouping
-    @handle = File.open(file_path, 'a')
-  end
-
-  def close_file
-    @handle.close
-  end
-
-  def file_path
-    @grouping_group[:description_args].first.match(/(.+)\sRequests/)
-    file_name = Regexp.last_match(1).gsub(' ', '').underscore
-
-    "#{api_docs_folder_path}#{file_name}_blueprint.md"
-  end
-
-  def write_resource_to_file
-    return if @@actions_covered.key?(resource)
-
-    @@actions_covered["#{resource}"] = []
-
-    @handle.write "## #{resource_description} [#{resource}]"
-    @handle.write("\n")
-  end
-
-  def write_action_to_file
-    return if @@actions_covered["#{resource}"].include?(action)
-
-    @@actions_covered["#{resource}"] << action
-
-    @handle.write "### #{action_description} [#{action}]"
-
-    query_strings = URI.decode(request.env['QUERY_STRING']).split('&')
-
-    @handle.write("\n")
-    write_request_to_file
-    write_response_to_file
-  end
-
-  def write_request_to_file
-    request_body = request.body.read
-
-    current_env  = request.env ? request.env : request.headers
-
-    authorization_header = current_env['HTTP_AUTHORIZATION'] || env['X-HTTP_AUTHORIZATION'] ||
-                           env['X_HTTP_AUTHORIZATION'] ||
-                           env['REDIRECT_X_HTTP_AUTHORIZATION'] ||
-                           env['AUTHORIZATION']
-
-    if request_body.present? || authorization_header.present? || request.env['QUERY_STRING']
-      @handle.write "+ Request #{request.content_type}\n\n"
-
-      if request.env['QUERY_STRING'].present?
-        @handle.write "+ Parameters\n\n".indent(4)
-        query_strings = URI.decode(request.env['QUERY_STRING']).split('&')
-
-        query_strings.each do |value|
-          key, example = value.split('=')
-          @handle.write "+ #{key} = '#{example}'\n".indent(12)
+    def write_resources
+      @groups.each do |_, group|
+        File.open(group.file_path, 'w+') do |handle|
+          handle.write group.to_s
         end
-        @handle.write("\n")
-      end
-
-      allowed_headers = %w(HTTP_AUTHORIZATION AUTHORIZATION CONTENT_TYPE)
-      @handle.write "+ Headers\n\n".indent(4)
-      current_env.each do |header, value|
-        next unless allowed_headers.include?(header)
-        header = header.gsub(/HTTP_/, '') if header == 'HTTP_AUTHORIZATION'
-        header = header.gsub(/CONTENT_TYPE/, 'CONTENT-TYPE') if header == 'CONTENT_TYPE'
-        @handle.write "#{header}: #{value}\n".indent(12)
-      end
-      @handle.write "\n"
-
-      # Request Body
-      if request_body.present? && request.content_type.to_s == 'application/json'
-        @handle.write "+ Body\n\n".indent(4) if authorization_header
-        @handle.write "#{JSON.pretty_generate(JSON.parse(request_body))}\n\n".indent(authorization_header ? 12 : 8)
       end
     end
-  end
 
-  def write_response_to_file
-    @handle.write "+ Response #{response.status} (#{response.content_type}; charset=#{response.charset})\n\n"
+    def group_name(group)
+      group[:description_args].first.match(/(.+)\sRequests/)
+      Regexp.last_match(1)
+    end
 
-    if response.body.present? && response.content_type.to_s =~ /application\/json/
-      @handle.write "#{JSON.pretty_generate(JSON.parse(response.body))}\n\n".indent(8)
+    def resource_name(group)
+      group[:description_args].first.match(/(.+)\[(.+)\]/)
+      Regexp.last_match(2)
+    end
+
+    def resource_description(group)
+      group[:description_args].first.match(/(.+)\[(.+)\]/)
+      Regexp.last_match(1)
+    end
+
+    def request_method(group_metas)
+      group_metas[-3][:description_args].first.match(/(.+)\[(.+)\]/)
+      Regexp.last_match(2).upcase
+    end
+
+    def action_indetifier(group_metas)
+      group_metas[-3][:description_args].first.match(/(.+)\[(.+)\]/)
+      Regexp.last_match(1)
     end
   end
 end

--- a/lib/rspec_api_blueprint/spec_blueprint_translator.rb
+++ b/lib/rspec_api_blueprint/spec_blueprint_translator.rb
@@ -19,8 +19,9 @@ class SpecBlueprintTranslator
       resource = (group.resources[name] ||= SpecBlueprintResource.new(name, resource_description(group_metas[-2])))
 
       request_method = request_method(group_metas)
-      action = (resource.actions[request_method] ||= SpecBlueprintAction.new(request_method, action_indetifier(group_metas)))
-      action.add_request_with_response request, response
+      action = (resource.actions[request_method] ||= SpecBlueprintAction.new(request_method,
+                                                                             action_indetifier(group_metas)))
+      action.add_transaction_example request, response, example.metadata[:as]
     end
 
     def end

--- a/lib/rspec_api_blueprint/version.rb
+++ b/lib/rspec_api_blueprint/version.rb
@@ -1,3 +1,3 @@
 module RspecApiBlueprint
-  VERSION = '0.0.11'
+  VERSION = '0.0.12'
 end


### PR DESCRIPTION
- Allow multiple transaction examples per action
- Remove HTTP code exclusions so errors are also included
- Accept any registered JSON mime type and not only "application/json" (eg "text/x-json")
- Allow to specify a request example identifier